### PR TITLE
Improve setup script OS checks

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,1 +1,11 @@
 # Scripts module
+
+The `setup.sh` script bootstraps the development environment. It installs the Rust compiler, CUDA toolkit, Node.js and configures pre-commit hooks. The script first detects your operating system via `/etc/os-release` or `uname`.
+
+On Debian or Ubuntu systems it will automatically install dependencies with `apt-get`. On any other operating system the script prints a message asking you to install these prerequisites manually.
+
+Run it from the repository root:
+
+```bash
+./scripts/setup.sh
+```

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -7,6 +7,22 @@ set -euo pipefail
 # Functions
 info() { echo -e "\033[1;34m[setup]\033[0m $1"; }
 
+# Detect operating system
+OS_ID="unknown"
+OS_LIKE=""
+if [ -f /etc/os-release ]; then
+    . /etc/os-release
+    OS_ID="$ID"
+    OS_LIKE="${ID_LIKE:-}"
+else
+    OS_ID="$(uname -s)"
+fi
+
+use_apt=false
+if [[ "$OS_ID" == "debian" || "$OS_ID" == "ubuntu" || "$OS_LIKE" == *debian* || "$OS_LIKE" == *ubuntu* ]]; then
+    use_apt=true
+fi
+
 install_rust() {
     if ! command -v cargo >/dev/null 2>&1; then
         info "Installing Rust via rustup"
@@ -19,9 +35,13 @@ install_rust() {
 
 install_cuda() {
     if ! command -v nvcc >/dev/null 2>&1; then
-        info "Installing NVIDIA CUDA toolkit (apt)"
-        sudo apt-get update
-        sudo apt-get install -y nvidia-cuda-toolkit
+        if $use_apt; then
+            info "Installing NVIDIA CUDA toolkit (apt)"
+            sudo apt-get update
+            sudo apt-get install -y nvidia-cuda-toolkit
+        else
+            info "Please install the NVIDIA CUDA toolkit manually for your OS."
+        fi
     else
         info "CUDA toolkit already installed"
     fi
@@ -29,9 +49,13 @@ install_cuda() {
 
 install_node() {
     if ! command -v node >/dev/null 2>&1; then
-        info "Installing Node.js (apt)"
-        sudo apt-get update
-        sudo apt-get install -y nodejs npm
+        if $use_apt; then
+            info "Installing Node.js (apt)"
+            sudo apt-get update
+            sudo apt-get install -y nodejs npm
+        else
+            info "Please install Node.js and npm manually for your OS."
+        fi
     else
         info "Node.js already installed"
     fi
@@ -46,6 +70,7 @@ setup_precommit() {
     pre-commit install
 }
 
+info "Detected OS: $OS_ID"
 install_rust
 install_cuda
 install_node


### PR DESCRIPTION
## Summary
- detect the OS in `scripts/setup.sh`
- only use `apt-get` on Debian or Ubuntu based systems
- document this OS-aware behavior in `scripts/README.md`

## Testing
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_687e9919a06883288d923dc1eee353c9