### PR TITLE
Add poc_sgp unit test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.16)
+project(OpenAstroViz CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+add_library(poc_sgp STATIC poc_sgp.cpp)
+target_include_directories(poc_sgp PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_compile_definitions(poc_sgp PUBLIC POC_SGP_NO_MAIN)
+
+find_package(GTest REQUIRED)
+
+add_executable(poc_sgp_test tests/poc_sgp_test.cpp)
+target_link_libraries(poc_sgp_test poc_sgp GTest::gtest GTest::gtest_main)
+
+enable_testing()
+add_test(NAME poc_sgp_test COMMAND poc_sgp_test)

--- a/poc_sgp.hpp
+++ b/poc_sgp.hpp
@@ -1,0 +1,27 @@
+#pragma once
+#include <string>
+#include <cmath>
+
+inline constexpr double kPi = 3.14159265358979323846;
+inline constexpr double kEarthMu = 3.986004418e14;  // m^3 s^-2
+inline constexpr double kEarthRad = 6378.137e3;     // m
+inline constexpr double deg2rad(double d) { return d * kPi / 180.0; }
+
+struct Tle {
+    std::string line1;
+    std::string line2;
+};
+
+struct Orbit {
+    double epoch_jd;      // Julian Date
+    double inc;           // inclination [rad]
+    double raan;          // right asc. node [rad]
+    double ecc;           // eccentricity
+    double argp;          // argument of perigee [rad]
+    double mean_anom;     // mean anomaly [rad]
+    double mean_motion;   // rad/s
+};
+
+Orbit parse_tle(const Tle &tle);
+void propagate(const Orbit &o, double dt, double &x, double &y, double &z);
+

--- a/tests/poc_sgp_test.cpp
+++ b/tests/poc_sgp_test.cpp
@@ -1,0 +1,23 @@
+#include "poc_sgp.hpp"
+#include <gtest/gtest.h>
+
+TEST(ParseTLE, ISSExample) {
+    Tle tle;
+    tle.line1 = "1 25544U 98067A   25202.31751672  .00008283  00000+0  15302-3 0  9997";
+    tle.line2 = "2 25544  51.6344 137.8967 0002535 105.6905 358.2995 15.49987077 52045";
+
+    Orbit o = parse_tle(tle);
+
+    EXPECT_NEAR(o.inc, deg2rad(51.6344), 1e-6);
+    EXPECT_NEAR(o.raan, deg2rad(137.8967), 1e-6);
+    EXPECT_NEAR(o.ecc, 0.0002535, 1e-7);
+    EXPECT_NEAR(o.argp, deg2rad(105.6905), 1e-6);
+    EXPECT_NEAR(o.mean_anom, deg2rad(358.2995), 1e-6);
+    double mm = 15.49987077 * 2.0 * kPi / 86400.0;
+    EXPECT_NEAR(o.mean_motion, mm, 1e-12);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary
- expose parse_tle and helpers via a header
- guard poc_sgp main with POC_SGP_NO_MAIN so it can be used as a library
- add GoogleTest-based unit test for parse_tle
- add minimal CMake build with test target

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_687e991958b4832898f61a5bf38e33dc