### PR TITLE
Add bench subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $ git clone https://github.com/openastroviz/openastroviz.git && cd openastroviz
 $ ./scripts/setup.sh          # installs Rust, CUDA, Node.js + pre‑commit hooks
 
 # 2 – build CUDA backend (requires NVIDIA + nvcc)
-$ cargo run -p openastrovizd -- --bench cuda   # benchmarks, STK vector tests
+$ cargo run -p openastrovizd -- bench cuda   # benchmarks, STK vector tests
 
 # 3 – run the web client (connects to local daemon)
 $ yarn --cwd web install && yarn --cwd web dev   # http://localhost:5173

--- a/daemon/openastrovizd/src/main.rs
+++ b/daemon/openastrovizd/src/main.rs
@@ -13,6 +13,11 @@ enum Commands {
     Start,
     /// Show daemon status
     Status,
+    /// Run benchmarks for a backend
+    Bench {
+        /// Backend to benchmark (e.g. cuda)
+        backend: String,
+    },
 }
 
 fn main() {
@@ -24,6 +29,9 @@ fn main() {
         }
         Some(Commands::Status) => {
             println!("Daemon status: unknown (placeholder)");
+        }
+        Some(Commands::Bench { backend }) => {
+            println!("Running benchmarks for {backend} backend... (placeholder)");
         }
         None => {
             println!("openastrovizd {}", env!("CARGO_PKG_VERSION"));


### PR DESCRIPTION
## Summary
- add `Bench` variant to `Commands` enum
- hook up match arm to print placeholder
- document `bench` subcommand in quick start docs

## Testing
- `cargo run -p openastrovizd -- bench cuda`

------
https://chatgpt.com/codex/tasks/task_e_687e991c3d608328b1998cf4730af047