### PR TITLE
Add bench command and module

### DIFF
--- a/daemon/openastrovizd/src/bench.rs
+++ b/daemon/openastrovizd/src/bench.rs
@@ -1,0 +1,31 @@
+use std::time::{Duration, Instant};
+
+/// Runs a stub benchmark for the given backend.
+///
+/// This currently performs a dummy computation to provide
+/// an example of how benchmarking might be implemented.
+pub fn bench_backend(backend: &str) -> Duration {
+    let start = Instant::now();
+    // Dummy workload: simple integer sum
+    let mut sum: u64 = 0;
+    for i in 0..1_000_000 {
+        sum = sum.wrapping_add(i);
+    }
+    let elapsed = start.elapsed();
+    println!(
+        "Benchmark for backend {backend}: computed sum={} in {:?}",
+        sum, elapsed
+    );
+    elapsed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bench_returns_duration() {
+        let dur = bench_backend("test");
+        assert!(dur > Duration::ZERO);
+    }
+}

--- a/daemon/openastrovizd/src/main.rs
+++ b/daemon/openastrovizd/src/main.rs
@@ -1,5 +1,8 @@
 use clap::{Parser, Subcommand};
 
+mod bench;
+use bench::bench_backend;
+
 #[derive(Parser)]
 #[command(author, version, about = "OpenAstroViz daemon")]
 struct Cli {
@@ -31,7 +34,7 @@ fn main() {
             println!("Daemon status: unknown (placeholder)");
         }
         Some(Commands::Bench { backend }) => {
-            println!("Running benchmarks for {backend} backend... (placeholder)");
+            bench_backend(&backend);
         }
         None => {
             println!("openastrovizd {}", env!("CARGO_PKG_VERSION"));


### PR DESCRIPTION
## Summary
- implement stub benchmarking function in `bench.rs`
- call the benchmark from the daemon Bench subcommand
- add a basic unit test for the benchmark

## Testing
- `cargo test -p openastrovizd`

------
https://chatgpt.com/codex/tasks/task_e_687f0214ba848328905ed44ac9c7e946