### PR TITLE
Add submodule README descriptions

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -1,1 +1,9 @@
 # Core module
+
+The `core` crate will hold the shared data structures and physics routines used by
+all other parts of OpenAstroViz.  Both the CPU reference path and the CUDA kernels
+will depend on this code so that they stay in sync.  Keeping the orbital mechanics
+logic here also makes it easier to port future backends such as WebGPU.
+
+For a project overview and build instructions see the
+[main README](../README.md).

--- a/cpu/README.md
+++ b/cpu/README.md
@@ -1,1 +1,11 @@
-# Cpu module
+# CPU module
+
+The `cpu` folder provides the baseline host implementation of the propagator.
+Initially it will be single threaded and prioritise correctness.  The GPU
+kernels are validated against this path and continuous integration runs its
+tests.
+
+Later milestones will explore SIMD and multithreaded optimisations here.
+
+See the [main README](../README.md) for how this module fits into the overall
+project.

--- a/cuda/README.md
+++ b/cuda/README.md
@@ -1,1 +1,12 @@
-# Cuda module
+# CUDA module
+
+This directory contains the NVIDIA GPU implementation of OpenAstroViz.  All
+high‑performance kernels such as SGP4 propagation and conjunction searches will
+live here.  The code is written in CUDA C++ and follows the style guide in
+[`docs/cuda_style.md`](../docs/cuda_style.md).
+
+These kernels are launched by the `openastrovizd` daemon to accelerate orbit
+calculations.
+
+For build instructions and the overall project vision, consult the
+[main README](../README.md).

--- a/daemon/README.md
+++ b/daemon/README.md
@@ -1,1 +1,12 @@
 # Daemon module
+
+`openastrovizd` is the Rust service that orchestrates the compute backends and
+streams data to the web client.  It exposes a small command‑line interface –
+`start`, `status` and `bench` – and will serve a WebSocket API for real‑time
+orbit information.
+
+During early milestones the daemon mostly shells out to the CPU or CUDA path
+for propagation work.
+
+See the [main README](../README.md) for quick start commands and the overall
+project layout.

--- a/web/README.md
+++ b/web/README.md
@@ -1,1 +1,9 @@
 # Web module
+
+The `web` directory contains the browser client built with React and Three.js.
+It connects to the local `openastrovizd` daemon over WebSockets to display
+satellites on an interactive globe and play back time steps.  The code base is
+TypeScript and uses Vite for development.
+
+Return to the [project README](../README.md) for installation instructions and
+more details about the overall architecture.


### PR DESCRIPTION
## Summary
- flesh out README docs in core, cpu, cuda, daemon and web modules
- describe the purpose of each directory and link back to the main README

## Testing
- `cargo test --workspace --quiet`
- `cargo fmt --all -- --check`
- `clang-format --version`
- `files=$(git ls-files '*.c' '*.cpp' '*.h' '*.hpp' '*.cu' '*.cuh'); if [ -n "$files" ]; then clang-format -n -Werror $files; fi`

------
https://chatgpt.com/codex/tasks/task_e_687f021006a88328b70ca28d83960442