### PR TITLE
Add web lint step to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,16 @@ jobs:
         run: cargo test --workspace --verbose
       - name: Check Rust formatting
         run: cargo fmt --all -- --check
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Install web dependencies
+        run: npm install
+        working-directory: web
+      - name: Run web linter
+        run: npm run lint
+        working-directory: web
       - name: Check C/C++ formatting
         run: |
           clang-format --version

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,8 @@ running `./scripts/setup.sh` once and then `pre-commit run --files <changed file
 
 * **C/C++/CUDA:** formatted with `clang-format`.
 * **Rust:** formatted with `rustfmt`.
-* **JavaScript/TypeScript:** formatted with `eslint --fix` and `prettier`.
+* **JavaScript/TypeScript:** formatted with `eslint --fix` and `prettier`. Run
+  `npm run lint` in `web/` before committing.
 * **CUDA kernels:** follow the guidance in [docs/cuda_style.md](docs/cuda_style.md).
 
 PRs that do not pass formatting checks will be blocked by CI.


### PR DESCRIPTION
## Summary
- install Node.js and run web linter in CI
- note npm lint usage in CONTRIBUTING

## Testing
- `cargo test --workspace --quiet`

------
https://chatgpt.com/codex/tasks/task_e_687f02120c688328a2c48de3da1b8c5b