### PR TITLE
Document module responsibilities

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -1,1 +1,25 @@
 # Core module
+
+The **core** crate will own OpenAstroViz's shared orbital mechanics logic. It
+will expose data types such as TLE parsing, time systems and coordinate
+transforms, and will host the physics models used by every backend.  A key
+design decision is that all GPU‑accelerated kernels will live behind a
+`GpuBackend` trait so that either a CPU or CUDA implementation can satisfy the
+same API.  This principle is called out in the project
+[roadmap](../ROADMAP.md) under *CUDA‑first, WebGPU‑ready*.
+
+Both the `cpu/` and `cuda/` folders will depend on this crate.  `core` provides
+the algorithms and trait definitions while the backends provide concrete
+implementations optimised for their respective targets.
+
+Planned responsibilities include:
+
+* **SGP4 propagator** – reference implementation used by tests and both
+  backends (see milestone *M1 – CUDA reference propagator* in the roadmap).
+* **Conjunction logic** – cell‑grid pruning and analytic miss‑distance solver
+  (roadmap *M2*).
+* **Common math utilities** – vector types, frame conversions and helpers used
+  by the daemon and web client.
+
+For build instructions and development philosophy refer to the top level
+[README](../README.md) and [ROADMAP](../ROADMAP.md).

--- a/cpu/README.md
+++ b/cpu/README.md
@@ -1,1 +1,23 @@
-# Cpu module
+# CPU backend
+
+The CPU backend provides a portable reference implementation of the propagation
+and conjunction kernels.  It is used by CI so that tests run on any machine and
+it allows contributors without an NVIDIA GPU to work on OpenAstroViz.  The
+project README notes:
+
+> If you don’t have an NVIDIA GPU, skip `cuda/` and work on the **cpu-simd**
+> reference path...
+
+Functionality here will mirror the interfaces defined in `core/` so that either
+this backend or the CUDA backend can be selected by `openastrovizd`.
+
+Planned responsibilities
+
+* **SIMD accelerated SGP4** – fast enough for correctness tests and low-end
+  deployments.
+* **CPU conjunction solver** – analytic miss distance calculation paired with
+  the grid pruning kernels in `cuda/`.
+
+Because this crate acts as the reference path, every commit must pass its unit
+tests.  See the development philosophy in the
+[ROADMAP](../ROADMAP.md#development-philosophy).

--- a/cuda/README.md
+++ b/cuda/README.md
@@ -1,1 +1,22 @@
-# Cuda module
+# CUDA backend
+
+The CUDA backend houses the high‑throughput GPU kernels used for real‑time orbit
+propagation and conjunction detection.  It is the focus of the early roadmap
+milestones – see *M1 – CUDA reference propagator* and *M2 – Conjunction kernel*
+in [ROADMAP](../ROADMAP.md).
+
+Kernels implemented here conform to the `GpuBackend` trait defined in `core/` so
+that the daemon can switch between CPU and GPU at runtime.  Developers are
+encouraged to follow the style guidance in
+[docs/cuda_style.md](../docs/cuda_style.md).
+
+Planned responsibilities
+
+* **SGP4 GPU kernels** – FP32/FP64 propagation validated against Vallado test
+  vectors.
+* **Cell‑grid pruning** – GPU‑accelerated close approach search producing a list
+  for the CPU solver in `cpu/`.
+
+Building the backend requires a working CUDA toolchain.  The top level
+[README](../README.md#-quick-start-development) shows how to build and benchmark
+the CUDA path via the `openastrovizd` bench command.


### PR DESCRIPTION
## Summary
- flesh out `core/`, `cpu/`, and `cuda/` README docs
- describe how the backends interact
- mention design philosophy and roadmap links

## Testing
- `cargo test --workspace --quiet`
- `pre-commit run --files core/README.md cpu/README.md cuda/README.md` *(fails: `.pre-commit-config.yaml` is missing)*

------
https://chatgpt.com/codex/tasks/task_e_688153a180708328922405ae6d86114b