### PR TITLE
Add rust-toolchain and document override

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ OpenAstroViz streams, propagates, and visualises **every tracked object in Earth
 # 1 – clone & bootstrap
 $ git clone https://github.com/openastroviz/openastroviz.git && cd openastroviz
 $ ./scripts/setup.sh          # installs Rust, CUDA, Node.js + pre‑commit hooks
+$ rustup override set stable  # ensure the stable toolchain locally
 
 # 2 – build CUDA backend (requires NVIDIA + nvcc)
 $ cargo run -p openastrovizd -- bench cuda   # benchmarks, STK vector tests

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "stable"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -31,6 +31,8 @@ install_rust() {
     else
         info "Rust already installed"
     fi
+    info "Setting local Rust toolchain to stable"
+    rustup override set stable
 }
 
 install_cuda() {


### PR DESCRIPTION
## Summary
- set the Rust toolchain using `rust-toolchain.toml`
- document `rustup override set` in the quick start instructions
- apply the override automatically in `scripts/setup.sh`

## Testing
- `~/.cargo/bin/cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_6881539f7ee08328a6647479ec3ed472