### PR TITLE
Add pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,27 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v20.1.8
+    hooks:
+      - id: clang-format
+        args: ["-style=file"]
+        files: '\.(c|cpp|h|hpp|cu|cuh)$'
+
+  - repo: https://github.com/doublify/pre-commit-rust
+    rev: v1.0
+    hooks:
+      - id: fmt
+      - id: clippy
+      - id: cargo-check
+
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.10.0.1
+    hooks:
+      - id: shellcheck

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,8 +8,13 @@ OpenAstroViz welcomes pull requests from everyone. The typical workflow is:
 4. Push the branch to your fork and open a pull request against `main`.
 5. Keep the PR rebased on the latest `main` until it is merged.
 
-CI runs on every commit. Ensure `pre-commit` passes locally before pushing by
-running `./scripts/setup.sh` once and then `pre-commit run --files <changed files>`.
+CI runs on every commit. Run `./scripts/setup.sh` once to install the
+`pre-commit` hooks. The hooks will automatically format code on each commit.
+You can also check formatting manually with:
+
+```bash
+pre-commit run --all-files
+```
 
 ### Code style
 
@@ -19,4 +24,3 @@ running `./scripts/setup.sh` once and then `pre-commit run --files <changed file
 * **CUDA kernels:** follow the guidance in [docs/cuda_style.md](docs/cuda_style.md).
 
 PRs that do not pass formatting checks will be blocked by CI.
-


### PR DESCRIPTION
## Summary
- add `.pre-commit-config.yaml` with clang-format, rustfmt, shellcheck, and common linters
- document running `pre-commit` in `CONTRIBUTING.md`

## Testing
- `pre-commit run --files .pre-commit-config.yaml CONTRIBUTING.md`

------
https://chatgpt.com/codex/tasks/task_e_6881539b6b3483289da0144e7e1808c7