### PR TITLE
Install Yarn in setup script

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,6 +1,6 @@
 # Scripts module
 
-The `setup.sh` script bootstraps the development environment. It installs the Rust compiler, CUDA toolkit, Node.js and configures pre-commit hooks. The script first detects your operating system via `/etc/os-release` or `uname`.
+The `setup.sh` script bootstraps the development environment. It installs the Rust compiler, CUDA toolkit, Node.js, Yarn and configures pre-commit hooks. The script first detects your operating system via `/etc/os-release` or `uname`.
 
 On Debian or Ubuntu systems it will automatically install dependencies with `apt-get`. On any other operating system the script prints a message asking you to install these prerequisites manually.
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -61,6 +61,15 @@ install_node() {
     fi
 }
 
+install_yarn() {
+    if ! command -v yarn >/dev/null 2>&1; then
+        info "Installing Yarn"
+        npm install -g yarn
+    else
+        info "Yarn already installed"
+    fi
+}
+
 setup_precommit() {
     if ! command -v pre-commit >/dev/null 2>&1; then
         info "Installing pre-commit"
@@ -74,6 +83,7 @@ info "Detected OS: $OS_ID"
 install_rust
 install_cuda
 install_node
+install_yarn
 setup_precommit
 
 info "Done. You may need to restart your shell for PATH changes to take effect."


### PR DESCRIPTION
## Summary
- install Yarn after Node in setup script
- mention Yarn in scripts README

## Testing
- `pre-commit run --files scripts/setup.sh scripts/README.md` *(fails: `.pre-commit-config.yaml is not a file`)*

------
https://chatgpt.com/codex/tasks/task_e_6881539a5ea08328a8a24966a503cb0e