### PR TITLE
Add yarn instructions to web README

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -1,1 +1,26 @@
 # Web module
+
+This directory contains the browser UI and supporting assets. The client is built with Vite and depends on Node.js and Yarn.
+
+## Prerequisites
+
+- **Node.js 18** (install via `scripts/setup.sh` or from [nodejs.org](https://nodejs.org/))
+- **Yarn** package manager
+
+Run the repository setup script from the project root to install these tools automatically:
+
+```bash
+./scripts/setup.sh
+```
+
+## Getting started
+
+Install dependencies and launch the development server:
+
+```bash
+cd web
+yarn install
+yarn dev
+```
+
+The site will be available at [http://localhost:5173](http://localhost:5173) by default.


### PR DESCRIPTION
## Summary
- document how to install dependencies and run the frontend with Yarn
- mention Node 18 requirement and point to setup.sh

## Testing
- `yarn --cwd web install` *(fails: No project found)*

------
https://chatgpt.com/codex/tasks/task_e_68823d1cb13c8328b32a6c299c3de210