### PR TITLE
Fix bench_cuda_subcommand closing brace

### DIFF
--- a/daemon/openastrovizd/tests/cli.rs
+++ b/daemon/openastrovizd/tests/cli.rs
@@ -35,6 +35,7 @@ fn bench_cuda_subcommand() {
         .assert()
         .success()
         .stdout(predicate::str::contains("cuda"));
+}
 
 #[test]
 fn help_includes_description() {


### PR DESCRIPTION
## Summary
- add missing closing brace so CLI tests compile

## Testing
- `cargo test` *(fails: failed to parse lock file)*
- `pre-commit run --files daemon/openastrovizd/tests/cli.rs` *(fails: failed to parse lock file)*

------
https://chatgpt.com/codex/tasks/task_e_68823d1bffa083289ac2c68ba77eb902