### PR TITLE
docs: document daemon usage

### DIFF
--- a/daemon/README.md
+++ b/daemon/README.md
@@ -1,1 +1,13 @@
-# Daemon module
+# OpenAstroViz Daemon
+
+`openastrovizd` is the long-running service that exposes OpenAstroViz compute backends to clients. It runs locally and bridges the web interface with CPU or GPU simulation kernels.
+
+## Basic usage
+
+```
+openastrovizd start         # launch the daemon
+openastrovizd status        # check if it is running
+openastrovizd bench <backend>  # benchmark a backend (e.g. cuda)
+```
+
+For detailed instructions and advanced options, see the [openastrovizd crate README](openastrovizd/README.md) or the project documentation.


### PR DESCRIPTION
## Summary
- clarify `openastrovizd`'s role as the project's daemon
- show how to start, check status, and benchmark the daemon
- link to detailed daemon documentation

## Testing
- `cargo test -p openastrovizd` *(fails: failed to parse lock file at Cargo.lock; package `aho-corasick` is specified twice)*

------
https://chatgpt.com/codex/tasks/task_e_688bff3df8fc8328802ed846882691e7