### PR TITLE
consolidate daemon start CLI tests

### DIFF
--- a/daemon/openastrovizd/tests/cli.rs
+++ b/daemon/openastrovizd/tests/cli.rs
@@ -11,15 +11,6 @@ fn runs_without_args_shows_version() {
 }
 
 #[test]
-fn start_subcommand() {
-    let mut cmd = Command::cargo_bin("openastrovizd").unwrap();
-    cmd.arg("start")
-        .assert()
-        .success()
-        .stdout(predicate::str::contains("Starting daemon"));
-}
-
-#[test]
 fn status_subcommand() {
     let mut cmd = Command::cargo_bin("openastrovizd").unwrap();
     cmd.arg("status")


### PR DESCRIPTION
## Summary
- merge duplicate daemon `start` subcommand tests into one

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_688bff3ea46483289c8a8ccbe64548f2