### PR TITLE
Refactor bench backend to use enums and structured errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,19 +12,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "anstream"
-version = "0.6.19"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -52,18 +43,18 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
 dependencies = [
  "windows-sys",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.9"
+version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
@@ -105,9 +96,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.41"
+version = "4.5.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
+checksum = "50fd97c9dc2399518aa331917ac6f274280ec5eb34e555dd291899745c48ec6f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -115,9 +106,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.41"
+version = "4.5.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
+checksum = "c35b5830294e1fa0462034af85cc95225a4cb07092c088c55bda3147cfcd8f65"
 dependencies = [
  "anstream",
  "anstyle",
@@ -366,20 +357,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-sys"
-version = "0.59.0"
+name = "windows-link"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.52.6"
+version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
+ "windows-link",
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
  "windows_i686_gnu",
@@ -392,48 +390,48 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.6"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.6"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.6"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.6"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.6"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.6"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.6"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.6"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"

--- a/daemon/openastrovizd/src/bench.rs
+++ b/daemon/openastrovizd/src/bench.rs
@@ -1,22 +1,45 @@
 use std::time::{Duration, Instant};
 
+use clap::ValueEnum;
+
+/// Supported backends for benchmarking.
+#[derive(Clone, Copy, Debug, ValueEnum)]
+pub enum Backend {
+    /// CUDA backend
+    Cuda,
+    /// CPU backend (currently unsupported)
+    Cpu,
+}
+
+/// Errors that can occur while benchmarking.
+#[derive(Debug)]
+pub enum BenchError {
+    /// The requested backend is not yet supported.
+    Unsupported,
+    /// The benchmark failed to execute.
+    Failed,
+}
+
 /// Runs a stub benchmark for the given backend.
 ///
-/// This currently performs a dummy computation to provide
-/// an example of how benchmarking might be implemented.
-pub fn bench_backend(backend: &str) -> Duration {
-    let start = Instant::now();
-    // Dummy workload: simple integer sum
-    let mut sum: u64 = 0;
-    for i in 0..1_000_000 {
-        sum = sum.wrapping_add(i);
+/// This currently performs a dummy computation to provide an example
+/// of how benchmarking might be implemented.
+pub fn bench_backend(backend: Backend) -> Result<Duration, BenchError> {
+    match backend {
+        Backend::Cuda => {
+            let start = Instant::now();
+            // Dummy workload: simple integer sum
+            let mut sum: u64 = 0;
+            for i in 0..1_000_000 {
+                sum = sum.wrapping_add(i);
+            }
+            let elapsed = start.elapsed();
+            // use sum so optimizer doesn't remove loop
+            let _ = sum;
+            Ok(elapsed)
+        }
+        Backend::Cpu => Err(BenchError::Unsupported),
     }
-    let elapsed = start.elapsed();
-    println!(
-        "Benchmark for backend {backend}: computed sum={} in {:?}",
-        sum, elapsed
-    );
-    elapsed
 }
 
 #[cfg(test)]
@@ -25,7 +48,12 @@ mod tests {
 
     #[test]
     fn bench_returns_duration() {
-        let dur = bench_backend("test");
+        let dur = bench_backend(Backend::Cuda).expect("benchmark failed");
         assert!(dur > Duration::ZERO);
+    }
+
+    #[test]
+    fn bench_returns_error_for_unsupported() {
+        assert!(matches!(bench_backend(Backend::Cpu), Err(BenchError::Unsupported)));
     }
 }

--- a/daemon/openastrovizd/tests/cli.rs
+++ b/daemon/openastrovizd/tests/cli.rs
@@ -20,12 +20,18 @@ fn status_subcommand() {
 }
 
 #[test]
-fn bench_cuda_subcommand() {
+fn bench_cuda_supported() {
     let mut cmd = Command::cargo_bin("openastrovizd").unwrap();
-    cmd.args(["bench", "cuda"])
+    cmd.args(["bench", "cuda"]).assert().success();
+}
+
+#[test]
+fn bench_cpu_unsupported() {
+    let mut cmd = Command::cargo_bin("openastrovizd").unwrap();
+    cmd.args(["bench", "cpu"])
         .assert()
-        .success()
-        .stdout(predicate::str::contains("cuda"));
+        .failure()
+        .stderr(contains("unsupported"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Introduce `Backend` enum and `BenchError` for stub benchmarking
- Return benchmark durations as `Result` and handle them in the CLI
- Test supported and unsupported backend CLI behavior

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68939a6009d08328b5112a591b3a0b09