### PR TITLE
Source cargo env after rustup install

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -40,7 +40,6 @@ install_rust() {
         if $use_apt; then
             info "Installing Rust via rustup"
             curl https://sh.rustup.rs -sSf | sh -s -- -y
-            export PATH="$HOME/.cargo/bin:$PATH"
         elif $use_brew; then
             info "Installing Rust via Homebrew"
             brew install rustup-init
@@ -48,6 +47,8 @@ install_rust() {
         else
             info "Please install Rust manually for your OS."
         fi
+        # Source cargo environment so rustup and cargo are in PATH for subsequent commands
+        [ -f "$HOME/.cargo/env" ] && source "$HOME/.cargo/env"
     else
         info "Rust already installed"
     fi


### PR DESCRIPTION
## Summary
- source `$HOME/.cargo/env` after rustup install so rustup/cargo are on PATH
- remove manual PATH export and rely on sourced environment

## Testing
- `shellcheck scripts/setup.sh` *(informational SC1091 warnings)*
- `cargo test` *(fails: package `aho-corasick` specified twice in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68939a5f40448328a5572e2ff2bb82e8