### PR TITLE
Check for curl before installing Rust

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -47,6 +47,20 @@ apt_update() {
 }
 
 install_rust() {
+    if ! command -v curl >/dev/null 2>&1; then
+        if $use_apt; then
+            info "curl not found. Installing curl (apt)"
+            apt_update
+            sudo apt-get install -y curl
+        elif $use_brew; then
+            info "curl not found. Installing curl (brew)"
+            brew install curl
+        else
+            info "Error: curl is required to install Rust. Please install curl and re-run."
+            return 1
+        fi
+    fi
+
     if ! command -v cargo >/dev/null 2>&1; then
         if $use_apt; then
             info "Installing Rust via rustup"


### PR DESCRIPTION
## Summary
- ensure `install_rust` checks for curl and installs it if possible
- gracefully abort when curl is missing and cannot be installed

## Testing
- `shellcheck scripts/setup.sh`
- `bash -n scripts/setup.sh`
- `cargo test` *(fails: Backend defined multiple times)*

------
https://chatgpt.com/codex/tasks/task_e_68955029f24483289b3a4e47bf9cace8