### PR TITLE
Use validated Julian date conversion and add test

### DIFF
--- a/julian.hpp
+++ b/julian.hpp
@@ -1,0 +1,44 @@
+#ifndef JULIAN_HPP
+#define JULIAN_HPP
+
+#include <cmath>
+
+inline bool is_leap_year(int year) {
+    return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0);
+}
+
+inline void doy_to_month_day(int year, int doy, int &month, int &day) {
+    static const int days_in_month[] = {31,28,31,30,31,30,31,31,30,31,30,31};
+    int m = 0;
+    while (m < 12) {
+        int dim = days_in_month[m];
+        if (m == 1 && is_leap_year(year)) {
+            dim = 29;
+        }
+        if (doy <= dim) {
+            month = m + 1;
+            day = doy;
+            return;
+        }
+        doy -= dim;
+        ++m;
+    }
+    month = 12;
+    day = 31;
+}
+
+inline double julian_date_from_calendar(int year, int month, int day, double frac_day) {
+    int a = (14 - month) / 12;
+    int y = year + 4800 - a;
+    int m = month + 12 * a - 3;
+    long jdn = day + (153 * m + 2) / 5 + 365 * y + y / 4 - y / 100 + y / 400 - 32045;
+    return jdn + frac_day - 0.5;
+}
+
+inline double julian_date_from_doy(int year, int doy, double frac_day) {
+    int month, day;
+    doy_to_month_day(year, doy, month, day);
+    return julian_date_from_calendar(year, month, day, frac_day);
+}
+
+#endif // JULIAN_HPP

--- a/poc_sgp.cpp
+++ b/poc_sgp.cpp
@@ -17,6 +17,8 @@
 #include <sstream>
 #include <string>
 
+#include "julian.hpp"
+
 constexpr double kPi = 3.14159265358979323846;
 constexpr double kEarthMu = 3.986004418e14; // m^3 s^‑2
 constexpr double kEarthRad = 6378.137e3;    // m (equatorial)
@@ -45,12 +47,7 @@ static Orbit parse_tle(const Tle &tle) {
     int doy = std::stoi(tle.line1.substr(20, 3));
     double frac_day = std::stod(tle.line1.substr(23, 8));
     int year = (yy < 57 ? 2000 + yy : 1900 + yy);
-    // Julian date conversion (simplified)
-    int A = (14 - 1) / 12;
-    int Y = year + 4800 - A;
-    int M = 1 + 12 * A - 3;
-    long JDN = doy + (153 * M + 2) / 5 + 365 * Y + Y / 4 - Y / 100 + Y / 400 - 32045;
-    o.epoch_jd = JDN + frac_day;
+    o.epoch_jd = julian_date_from_doy(year, doy, frac_day);
 
     o.inc = deg2rad(std::stod(tle.line2.substr(8, 8)));
     o.raan = deg2rad(std::stod(tle.line2.substr(17, 8)));

--- a/tests/julian_test.cpp
+++ b/tests/julian_test.cpp
@@ -1,0 +1,12 @@
+#include <cassert>
+#include <cmath>
+#include "julian.hpp"
+
+int main() {
+    double jd1 = julian_date_from_doy(2000, 1, 0.5);
+    assert(std::abs(jd1 - 2451545.0) < 1e-6);
+
+    double jd2 = julian_date_from_doy(2021, 275, 0.59097222);
+    assert(std::abs(jd2 - 2459490.09097222) < 1e-6);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- replace simplified epoch Julian date logic with full day-of-year to calendar conversion
- add header and unit test to verify Julian dates for known epochs

## Testing
- `g++ -std=c++17 -I. tests/julian_test.cpp -o tests/julian_test && ./tests/julian_test`


------
https://chatgpt.com/codex/tasks/task_e_6895502af23c8328b4787dcb92fb784b