### PR TITLE
Check python3 before installing pre-commit

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -59,6 +59,7 @@ install_rust() {
             info "Please install Rust manually for your OS."
         fi
         # Source cargo environment so rustup and cargo are in PATH for subsequent commands
+        # shellcheck source=/dev/null
         [ -f "$HOME/.cargo/env" ] && source "$HOME/.cargo/env"
     else
         info "Rust already installed"
@@ -114,8 +115,13 @@ install_yarn() {
 
 setup_precommit() {
     if ! command -v pre-commit >/dev/null 2>&1; then
-        info "Installing pre-commit"
-        pip install --user pre-commit
+        if command -v python3 >/dev/null 2>&1; then
+            info "Installing pre-commit"
+            python3 -m pip install --user pre-commit
+        else
+            info "Warning: python3 not found. Skipping pre-commit installation."
+            return
+        fi
     fi
     info "Installing git hooks"
     pre-commit install


### PR DESCRIPTION
## Summary
- verify python3 is installed before attempting pre-commit installation
- install pre-commit via `python3 -m pip` and warn if python3 missing

## Testing
- `pre-commit run --files scripts/setup.sh`


------
https://chatgpt.com/codex/tasks/task_e_6895502a682c8328a2db1ca4cf872b92