### PR TITLE
Remove redundant benchmark invocation

### DIFF
--- a/daemon/openastrovizd/src/main.rs
+++ b/daemon/openastrovizd/src/main.rs
@@ -49,8 +49,6 @@ fn main() {
                     std::process::exit(1);
                 }
             }
-
-            bench_backend(backend);
         }
         None => {
             println!("openastrovizd {}", env!("CARGO_PKG_VERSION"));


### PR DESCRIPTION
## Summary
- remove duplicate `bench_backend` call in CLI bench command

## Testing
- `cargo test -p openastrovizd`


------
https://chatgpt.com/codex/tasks/task_e_689d27c8d0e083289de3bf711ac4991c