### PR TITLE
Add daemon lifecycle helpers and update CLI tests

### DIFF
--- a/daemon/openastrovizd/src/daemon.rs
+++ b/daemon/openastrovizd/src/daemon.rs
@@ -1,0 +1,17 @@
+use std::io;
+
+/// Starts the OpenAstroViz daemon.
+///
+/// This is currently a stub that should be replaced with real startup logic.
+pub fn start_daemon() -> Result<String, io::Error> {
+    // TODO: implement daemon startup
+    Ok(String::from("Daemon started (stub)"))
+}
+
+/// Checks the status of the OpenAstroViz daemon.
+///
+/// This is currently a stub that should be replaced with real status checking logic.
+pub fn check_status() -> Result<String, io::Error> {
+    // TODO: implement daemon status check
+    Ok(String::from("Daemon is not running (stub)"))
+}

--- a/daemon/openastrovizd/src/main.rs
+++ b/daemon/openastrovizd/src/main.rs
@@ -2,6 +2,7 @@ use clap::{Parser, Subcommand};
 
 mod backend;
 mod bench;
+mod daemon;
 use backend::Backend;
 use bench::{bench_backend, BenchError};
 
@@ -29,12 +30,20 @@ fn main() {
     let cli = Cli::parse();
 
     match cli.command {
-        Some(Commands::Start) => {
-            println!("Starting daemon... (placeholder)");
-        }
-        Some(Commands::Status) => {
-            println!("Daemon status: unknown (placeholder)");
-        }
+        Some(Commands::Start) => match daemon::start_daemon() {
+            Ok(message) => println!("{message}"),
+            Err(e) => {
+                eprintln!("Failed to start daemon: {e}");
+                std::process::exit(1);
+            }
+        },
+        Some(Commands::Status) => match daemon::check_status() {
+            Ok(status) => println!("{status}"),
+            Err(e) => {
+                eprintln!("Failed to check daemon status: {e}");
+                std::process::exit(1);
+            }
+        },
         Some(Commands::Bench { backend }) => {
             match bench_backend(backend) {
                 Ok(duration) => {

--- a/daemon/openastrovizd/tests/cli.rs
+++ b/daemon/openastrovizd/tests/cli.rs
@@ -16,7 +16,7 @@ fn status_subcommand() {
     cmd.arg("status")
         .assert()
         .success()
-        .stdout(predicate::str::contains("Daemon status"));
+        .stdout(predicate::str::contains("Daemon is not running"));
 }
 
 #[test]
@@ -61,5 +61,5 @@ fn start_subcommand_outputs_message() {
         .arg("start")
         .assert()
         .success()
-        .stdout(contains("Starting daemon"));
+        .stdout(contains("Daemon started"));
 }


### PR DESCRIPTION
## Summary
- route `start` and `status` subcommands through lifecycle helpers
- stub out `start_daemon` and `check_status` helpers for future implementation
- update CLI integration tests for new behavior

## Testing
- `cargo test -p openastrovizd`


------
https://chatgpt.com/codex/tasks/task_e_689d27c9f4dc83289b837bf231e48c01