### PR TITLE
Validate day-of-year in Julian conversion

### DIFF
--- a/julian.hpp
+++ b/julian.hpp
@@ -1,14 +1,20 @@
 #ifndef JULIAN_HPP
 #define JULIAN_HPP
 
+#include <cassert>
 #include <cmath>
 
 inline bool is_leap_year(int year) {
     return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0);
 }
 
-inline void doy_to_month_day(int year, int doy, int &month, int &day) {
-    static const int days_in_month[] = {31,28,31,30,31,30,31,31,30,31,30,31};
+inline bool doy_to_month_day(int year, int doy, int &month, int &day) {
+    const int max_doy = is_leap_year(year) ? 366 : 365;
+    if (doy < 1 || doy > max_doy) {
+        return false;
+    }
+
+    static const int days_in_month[] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
     int m = 0;
     while (m < 12) {
         int dim = days_in_month[m];
@@ -18,13 +24,12 @@ inline void doy_to_month_day(int year, int doy, int &month, int &day) {
         if (doy <= dim) {
             month = m + 1;
             day = doy;
-            return;
+            return true;
         }
         doy -= dim;
         ++m;
     }
-    month = 12;
-    day = 31;
+    return false; // Should never reach here if input range is validated
 }
 
 inline double julian_date_from_calendar(int year, int month, int day, double frac_day) {
@@ -37,7 +42,8 @@ inline double julian_date_from_calendar(int year, int month, int day, double fra
 
 inline double julian_date_from_doy(int year, int doy, double frac_day) {
     int month, day;
-    doy_to_month_day(year, doy, month, day);
+    bool ok = doy_to_month_day(year, doy, month, day);
+    assert(ok && "Day of year out of range");
     return julian_date_from_calendar(year, month, day, frac_day);
 }
 

--- a/tests/julian_test.cpp
+++ b/tests/julian_test.cpp
@@ -1,6 +1,6 @@
+#include "julian.hpp"
 #include <cassert>
 #include <cmath>
-#include "julian.hpp"
 
 int main() {
     double jd1 = julian_date_from_doy(2000, 1, 0.5);
@@ -8,5 +8,9 @@ int main() {
 
     double jd2 = julian_date_from_doy(2021, 275, 0.59097222);
     assert(std::abs(jd2 - 2459490.09097222) < 1e-6);
+
+    int month, day;
+    bool ok = doy_to_month_day(2021, 366, month, day);
+    assert(!ok);
     return 0;
 }


### PR DESCRIPTION
## Summary
- add range checks for day-of-year before converting to month/day
- assert when `julian_date_from_doy` is called with an invalid DOY
- test rejection of an out-of-range day-of-year value

## Testing
- `g++ -I. tests/julian_test.cpp -o julian_test && ./julian_test`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_689d27ce005883289ba9d1ba8dcb7f3b