### PR TITLE
chore: drop unused sstream include

### DIFF
--- a/poc_sgp.cpp
+++ b/poc_sgp.cpp
@@ -14,7 +14,6 @@
 #include <cstdlib>
 #include <iomanip>
 #include <iostream>
-#include <sstream>
 #include <string>
 
 #include "julian.hpp"


### PR DESCRIPTION
## Summary
- remove unused `<sstream>` include from `poc_sgp.cpp`

## Testing
- `g++ -O2 -std=c++17 poc_sgp.cpp -o poc_sgp`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_689d27cccd848328b8dfc39fcc8a30c8