### PR TITLE
Wrap julian utilities in namespace

### DIFF
--- a/julian.hpp
+++ b/julian.hpp
@@ -3,6 +3,8 @@
 
 #include <cmath>
 
+namespace julian {
+
 inline bool is_leap_year(int year) {
     return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0);
 }
@@ -40,5 +42,7 @@ inline double julian_date_from_doy(int year, int doy, double frac_day) {
     doy_to_month_day(year, doy, month, day);
     return julian_date_from_calendar(year, month, day, frac_day);
 }
+
+} // namespace julian
 
 #endif // JULIAN_HPP

--- a/poc_sgp.cpp
+++ b/poc_sgp.cpp
@@ -47,7 +47,7 @@ static Orbit parse_tle(const Tle &tle) {
     int doy = std::stoi(tle.line1.substr(20, 3));
     double frac_day = std::stod(tle.line1.substr(23, 8));
     int year = (yy < 57 ? 2000 + yy : 1900 + yy);
-    o.epoch_jd = julian_date_from_doy(year, doy, frac_day);
+    o.epoch_jd = julian::julian_date_from_doy(year, doy, frac_day);
 
     o.inc = deg2rad(std::stod(tle.line2.substr(8, 8)));
     o.raan = deg2rad(std::stod(tle.line2.substr(17, 8)));

--- a/tests/julian_test.cpp
+++ b/tests/julian_test.cpp
@@ -3,10 +3,10 @@
 #include "julian.hpp"
 
 int main() {
-    double jd1 = julian_date_from_doy(2000, 1, 0.5);
+    double jd1 = julian::julian_date_from_doy(2000, 1, 0.5);
     assert(std::abs(jd1 - 2451545.0) < 1e-6);
 
-    double jd2 = julian_date_from_doy(2021, 275, 0.59097222);
+    double jd2 = julian::julian_date_from_doy(2021, 275, 0.59097222);
     assert(std::abs(jd2 - 2459490.09097222) < 1e-6);
     return 0;
 }


### PR DESCRIPTION
## Summary
- encapsulate Julian date helpers in new `julian` namespace
- update test and sample program to call namespaced functions

## Testing
- `g++ -std=c++17 -I. tests/julian_test.cpp -o tests/julian_test`
- `./tests/julian_test`
- `g++ -std=c++17 -I. poc_sgp.cpp -o poc_sgp`


------
https://chatgpt.com/codex/tasks/task_e_689d27cbef8483288a17f0d80af4dd3e