### PR TITLE
Add Catch2 framework for Julian date tests

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -10,6 +10,16 @@ Run it from the repository root:
 ./scripts/setup.sh
 ```
 
+## Testing
+
+The `run_tests.sh` script compiles and runs the C++ unit tests. Ensure the
+Catch2 library is installed (for example via `apt-get install catch2`) and
+execute:
+
+```bash
+./scripts/run_tests.sh
+```
+
 ## Windows
 
 `setup.sh` does not currently automate installation on Windows. Install the following tools manually:

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+g++ -std=c++17 -I. tests/julian_test.cpp -o tests/julian_tests -lCatch2Main -lCatch2
+./tests/julian_tests

--- a/tests/julian_test.cpp
+++ b/tests/julian_test.cpp
@@ -1,12 +1,16 @@
-#include <cassert>
+#include <catch2/catch_test_macros.hpp>
 #include <cmath>
+
 #include "julian.hpp"
 
-int main() {
-    double jd1 = julian_date_from_doy(2000, 1, 0.5);
-    assert(std::abs(jd1 - 2451545.0) < 1e-6);
+TEST_CASE("julian_date_from_doy computes expected Julian date", "[julian]") {
+    SECTION("J2000 epoch") {
+        double jd1 = julian_date_from_doy(2000, 1, 0.5);
+        REQUIRE(std::abs(jd1 - 2451545.0) < 1e-6);
+    }
 
-    double jd2 = julian_date_from_doy(2021, 275, 0.59097222);
-    assert(std::abs(jd2 - 2459490.09097222) < 1e-6);
-    return 0;
+    SECTION("2021 day 275") {
+        double jd2 = julian_date_from_doy(2021, 275, 0.59097222);
+        REQUIRE(std::abs(jd2 - 2459490.09097222) < 1e-6);
+    }
 }


### PR DESCRIPTION
## Summary
- add Catch2-based unit tests for Julian date conversions
- provide script to build and run C++ tests via Catch2
- document how to run the tests

## Testing
- `pre-commit run --files tests/julian_test.cpp scripts/run_tests.sh scripts/README.md`
- `scripts/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_689d27cee6c88328911a4d3fe0905857