### PR TITLE
Add simple CPU benchmark support

### DIFF
--- a/daemon/openastrovizd/src/backend.rs
+++ b/daemon/openastrovizd/src/backend.rs
@@ -6,7 +6,7 @@ use std::fmt;
 pub enum Backend {
     /// CUDA backend
     Cuda,
-    /// CPU backend (currently unsupported)
+    /// CPU backend
     Cpu,
 }
 

--- a/daemon/openastrovizd/src/bench.rs
+++ b/daemon/openastrovizd/src/bench.rs
@@ -4,8 +4,11 @@ use crate::backend::Backend;
 
 /// Errors that can occur while benchmarking.
 #[derive(Debug)]
+#[allow(dead_code)]
 pub enum BenchError {
-    /// The requested backend is not yet supported.
+    /// The requested backend is not supported.
+    ///
+    /// Currently supported backends are [`Backend::Cpu`] and [`Backend::Cuda`].
     Unsupported,
     /// The benchmark failed to execute.
     Failed,
@@ -17,7 +20,7 @@ pub enum BenchError {
 /// of how benchmarking might be implemented.
 pub fn bench_backend(backend: Backend) -> Result<Duration, BenchError> {
     match backend {
-        Backend::Cuda => {
+        Backend::Cuda | Backend::Cpu => {
             let start = Instant::now();
             // Dummy workload: simple integer sum
             let mut sum: u64 = 0;
@@ -29,7 +32,6 @@ pub fn bench_backend(backend: Backend) -> Result<Duration, BenchError> {
             let _ = sum;
             Ok(elapsed)
         }
-        Backend::Cpu => Err(BenchError::Unsupported),
     }
 }
 
@@ -42,13 +44,8 @@ mod tests {
     fn bench_returns_duration() {
         let dur = bench_backend(Backend::Cuda).expect("benchmark failed");
         assert!(dur > Duration::ZERO);
-    }
 
-    #[test]
-    fn bench_returns_error_for_unsupported() {
-        assert!(matches!(
-            bench_backend(Backend::Cpu),
-            Err(BenchError::Unsupported)
-        ));
+        let dur = bench_backend(Backend::Cpu).expect("benchmark failed");
+        assert!(dur > Duration::ZERO);
     }
 }

--- a/daemon/openastrovizd/tests/cli.rs
+++ b/daemon/openastrovizd/tests/cli.rs
@@ -26,12 +26,9 @@ fn bench_cuda_supported() {
 }
 
 #[test]
-fn bench_cpu_unsupported() {
+fn bench_cpu_supported() {
     let mut cmd = Command::cargo_bin("openastrovizd").unwrap();
-    cmd.args(["bench", "cpu"])
-        .assert()
-        .failure()
-        .stderr(contains("unsupported"));
+    cmd.args(["bench", "cpu"]).assert().success();
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- support CPU backend benchmarking with dummy integer sum loop
- document supported backends and update CLI tests

## Testing
- `cargo test -p openastrovizd`


------
https://chatgpt.com/codex/tasks/task_e_689d27cad62c8328a410454b36fb30ea