### PR TITLE
streamline node setup in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,22 +31,14 @@ jobs:
         run: npm install -g yarn
       - name: Install web dependencies
         run: yarn --cwd web install --frozen-lockfile
+      - name: Run web linter
+        run: yarn --cwd web lint
       - name: Build daemon
         run: cargo build -p openastrovizd --verbose
       - name: Run tests
         run: cargo test --workspace --verbose
       - name: Check Rust formatting
         run: cargo fmt --all -- --check
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18
-      - name: Install web dependencies
-        run: npm install
-        working-directory: web
-      - name: Run web linter
-        run: npm run lint
-        working-directory: web
       - name: Check C/C++ formatting
         run: |
           clang-format --version


### PR DESCRIPTION
## Summary
- streamline Node setup by removing redundant step
- use Yarn for all web dependency and linting tasks

## Testing
- `yarn --cwd web install --frozen-lockfile` *(fails: No project found)*
- `yarn --cwd web lint` *(fails: No project found)*
- `cargo build -p openastrovizd --verbose`
- `cargo test --workspace --verbose`
- `cargo fmt --all -- --check` *(fails: Diff in daemon/openastrovizd/src/main.rs)*
- `files=$(git ls-files '*.c' '*.cpp' '*.h' '*.hpp' '*.cu' '*.cuh'); if [ -n "$files" ]; then clang-format -n -Werror $files; fi` *(fails: tests/julian_test.cpp:8:22: error)*

------
https://chatgpt.com/codex/tasks/task_e_68a354b7ed188328b37c85114f280867