### PR TITLE
Handle invalid DOY in Julian conversion

### DIFF
--- a/julian.hpp
+++ b/julian.hpp
@@ -1,8 +1,8 @@
 #ifndef JULIAN_HPP
 #define JULIAN_HPP
 
-#include <cassert>
 #include <cmath>
+#include <optional>
 
 namespace julian {
 
@@ -42,10 +42,14 @@ inline double julian_date_from_calendar(int year, int month, int day, double fra
     return jdn + frac_day - 0.5;
 }
 
-inline double julian_date_from_doy(int year, int doy, double frac_day) {
+/// Convert a year and day-of-year to a Julian Date.
+///
+/// Returns `std::nullopt` when `doy` is outside the valid range for `year`.
+inline std::optional<double> julian_date_from_doy(int year, int doy, double frac_day) {
     int month, day;
-    bool ok = doy_to_month_day(year, doy, month, day);
-    assert(ok && "Day of year out of range");
+    if (!doy_to_month_day(year, doy, month, day)) {
+        return std::nullopt;
+    }
     return julian_date_from_calendar(year, month, day, frac_day);
 }
 

--- a/tests/julian_test.cpp
+++ b/tests/julian_test.cpp
@@ -2,21 +2,24 @@
 #include <cassert>
 #include <cmath>
 
-#include <catch2/catch_test_macros.hpp>
-#include <cmath>
-
-#include "julian.hpp"
-
-
 int main() {
-    double jd1 = julian::julian_date_from_doy(2000, 1, 0.5);
-    assert(std::abs(jd1 - 2451545.0) < 1e-6);
+    // Valid conversion: start of J2000
+    auto jd1 = julian::julian_date_from_doy(2000, 1, 0.5);
+    assert(jd1);
+    assert(std::abs(*jd1 - 2451545.0) < 1e-6);
 
-    double jd2 = julian::julian_date_from_doy(2021, 275, 0.59097222);
-    assert(std::abs(jd2 - 2459490.09097222) < 1e-6);
+    // Another valid date
+    auto jd2 = julian::julian_date_from_doy(2021, 275, 0.59097222);
+    assert(jd2);
+    assert(std::abs(*jd2 - 2459490.09097222) < 1e-6);
 
-    int month, day;
-    bool ok = doy_to_month_day(2021, 366, month, day);
-    assert(!ok);
+    // Out-of-range day-of-year for non-leap year should fail
+    auto jd_invalid = julian::julian_date_from_doy(2021, 366, 0.0);
+    assert(!jd_invalid);
+
+    // Out-of-range day-of-year (zero) should also fail
+    auto jd_zero = julian::julian_date_from_doy(2021, 0, 0.0);
+    assert(!jd_zero);
+
     return 0;
 }


### PR DESCRIPTION
## Summary
- Return `std::optional<double>` from `julian_date_from_doy` instead of asserting on out-of-range input
- Propagate conversion failures in TLE parsing and tests
- Add tests for valid conversions and invalid day-of-year values

## Testing
- `g++ -std=c++20 -I. tests/julian_test.cpp -o /tmp/julian_test && /tmp/julian_test`
- `g++ -std=c++20 poc_sgp.cpp -o /tmp/poc_sgp`


------
https://chatgpt.com/codex/tasks/task_e_68a354ba845c83288b40c796eb9b4306