### PR TITLE
Implement daemon start and status logic with tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,6 +212,7 @@ version = "0.1.0"
 dependencies = [
  "assert_cmd",
  "clap",
+ "libc",
  "predicates",
 ]
 

--- a/daemon/README.md
+++ b/daemon/README.md
@@ -10,4 +10,9 @@ openastrovizd status        # check if it is running
 openastrovizd bench <backend>  # benchmark a backend (e.g. cuda)
 ```
 
+Starting the daemon spawns a lightweight background process and writes its
+process ID to a file in the system temporary directory. Subsequent `status`
+checks read this file and verify that the process is still alive, providing a
+simple way to monitor the daemon.
+
 For detailed instructions and advanced options, see the [openastrovizd crate README](openastrovizd/README.md) or the project documentation.

--- a/daemon/openastrovizd/Cargo.toml
+++ b/daemon/openastrovizd/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
+libc = "0.2"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/daemon/openastrovizd/README.md
+++ b/daemon/openastrovizd/README.md
@@ -22,6 +22,12 @@ The daemon provides a few subcommands:
 
 Running `openastrovizd` with no arguments prints the version.
 
+When the `start` subcommand is executed the daemon spawns a background
+process and writes its process ID to a file named `openastrovizd.pid` in the
+system temporary directory. The `status` subcommand reads this file and checks
+whether the recorded process is still alive, allowing the daemon to be
+monitored with simple status queries.
+
 ## Example usage
 
 ```bash

--- a/daemon/openastrovizd/src/daemon.rs
+++ b/daemon/openastrovizd/src/daemon.rs
@@ -1,17 +1,117 @@
+use std::env;
+use std::fs;
 use std::io;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
 
-/// Starts the OpenAstroViz daemon.
-///
-/// This is currently a stub that should be replaced with real startup logic.
-pub fn start_daemon() -> Result<String, io::Error> {
-    // TODO: implement daemon startup
-    Ok(String::from("Daemon started (stub)"))
+fn pid_file() -> PathBuf {
+    env::temp_dir().join("openastrovizd.pid")
 }
 
-/// Checks the status of the OpenAstroViz daemon.
+/// Starts the OpenAstroViz daemon by spawning a background process.
 ///
-/// This is currently a stub that should be replaced with real status checking logic.
+/// The command used can be overridden with the `OPENASTROVIZD_DAEMON_CMD`
+/// environment variable (defaults to `sleep`). The optional argument for the
+/// command can be set via `OPENASTROVIZD_DAEMON_ARG` (defaults to `60`).
+/// A PID file is written to the system temporary directory so that the daemon
+/// can later be queried.
+pub fn start_daemon() -> Result<String, io::Error> {
+    let cmd = env::var("OPENASTROVIZD_DAEMON_CMD").unwrap_or_else(|_| "sleep".to_string());
+    let arg = env::var("OPENASTROVIZD_DAEMON_ARG").unwrap_or_else(|_| "60".to_string());
+
+    let child = Command::new(&cmd)
+        .arg(&arg)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()?;
+    let pid = child.id();
+    fs::write(pid_file(), pid.to_string())?;
+
+    Ok(format!("Daemon started with pid {pid}"))
+}
+
+#[cfg(unix)]
+fn process_running(pid: u32) -> bool {
+    unsafe { libc::kill(pid as i32, 0) == 0 }
+}
+
+#[cfg(not(unix))]
+fn process_running(pid: u32) -> bool {
+    if let Ok(out) = Command::new("tasklist").output() {
+        let list = String::from_utf8_lossy(&out.stdout);
+        list.contains(&pid.to_string())
+    } else {
+        false
+    }
+}
+
+/// Checks the status of the OpenAstroViz daemon by reading the PID file and
+/// verifying that the process is still alive.
 pub fn check_status() -> Result<String, io::Error> {
-    // TODO: implement daemon status check
-    Ok(String::from("Daemon is not running (stub)"))
+    match fs::read_to_string(pid_file()) {
+        Ok(pid_str) => {
+            if let Ok(pid) = pid_str.trim().parse::<u32>() {
+                if process_running(pid) {
+                    return Ok(format!("Daemon is running with pid {pid}"));
+                }
+            }
+            Ok(String::from("Daemon is not running"))
+        }
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(String::from("Daemon is not running")),
+        Err(e) => Err(e),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    static TEST_MUTEX: Mutex<()> = Mutex::new(());
+
+    fn cleanup() {
+        let pid_path = pid_file();
+        if let Ok(pid_str) = fs::read_to_string(&pid_path) {
+            if let Ok(pid) = pid_str.trim().parse::<i32>() {
+                #[cfg(unix)]
+                unsafe {
+                    libc::kill(pid, libc::SIGTERM);
+                }
+                #[cfg(not(unix))]
+                let _ = Command::new("taskkill")
+                    .args(["/PID", &pid.to_string(), "/F"])
+                    .status();
+            }
+        }
+        let _ = fs::remove_file(pid_path);
+    }
+
+    #[test]
+    fn start_and_status_success() {
+        let _lock = TEST_MUTEX.lock().unwrap();
+        cleanup();
+        let msg = start_daemon().expect("start failed");
+        assert!(msg.contains("Daemon started"));
+        let status = check_status().expect("status failed");
+        assert!(status.contains("running"));
+        cleanup();
+    }
+
+    #[test]
+    fn start_failure() {
+        let _lock = TEST_MUTEX.lock().unwrap();
+        cleanup();
+        env::set_var("OPENASTROVIZD_DAEMON_CMD", "/nonexistent");
+        assert!(start_daemon().is_err());
+        env::remove_var("OPENASTROVIZD_DAEMON_CMD");
+        cleanup();
+    }
+
+    #[test]
+    fn status_not_running() {
+        let _lock = TEST_MUTEX.lock().unwrap();
+        cleanup();
+        let status = check_status().unwrap();
+        assert!(status.contains("not running"));
+    }
 }

--- a/daemon/openastrovizd/tests/cli.rs
+++ b/daemon/openastrovizd/tests/cli.rs
@@ -1,6 +1,29 @@
 use assert_cmd::Command;
 use predicates::prelude::*;
 use predicates::str::contains;
+use std::fs;
+#[cfg(not(unix))]
+use std::process::Command as StdCommand;
+use std::sync::Mutex;
+
+static TEST_MUTEX: Mutex<()> = Mutex::new(());
+
+fn cleanup() {
+    let pid_path = std::env::temp_dir().join("openastrovizd.pid");
+    if let Ok(pid_str) = fs::read_to_string(&pid_path) {
+        if let Ok(pid) = pid_str.trim().parse::<i32>() {
+            #[cfg(unix)]
+            unsafe {
+                libc::kill(pid, libc::SIGTERM);
+            }
+            #[cfg(not(unix))]
+            let _ = StdCommand::new("taskkill")
+                .args(["/PID", &pid.to_string(), "/F"])
+                .status();
+        }
+    }
+    let _ = fs::remove_file(pid_path);
+}
 
 #[test]
 fn runs_without_args_shows_version() {
@@ -12,6 +35,8 @@ fn runs_without_args_shows_version() {
 
 #[test]
 fn status_subcommand() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    cleanup();
     let mut cmd = Command::cargo_bin("openastrovizd").unwrap();
     cmd.arg("status")
         .assert()
@@ -53,10 +78,13 @@ fn help_includes_description() {
 
 #[test]
 fn start_subcommand_outputs_message() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    cleanup();
     Command::cargo_bin("openastrovizd")
         .unwrap()
         .arg("start")
         .assert()
         .success()
         .stdout(contains("Daemon started"));
+    cleanup();
 }


### PR DESCRIPTION
## Summary
- spawn configurable background process and track its PID
- report daemon status by checking the PID file
- document daemon lifecycle and add tests for success and failure paths

## Testing
- `cargo test -p openastrovizd`


------
https://chatgpt.com/codex/tasks/task_e_68a354b98d788328b8f16ecce34d9f58