### PR TITLE
Fix duplicated includes and test cases in julian tests

### DIFF
--- a/tests/julian_test.cpp
+++ b/tests/julian_test.cpp
@@ -1,26 +1,15 @@
-#include "julian.hpp"
-#include <catch2/catch_test_macros.hpp>
-
+#include <catch2/catch_all.hpp>
 #include <cmath>
 #include "julian.hpp"
 
 TEST_CASE("julian_date_from_doy computes expected Julian dates") {
-    double jd1 = julian::julian_date_from_doy(2000, 1, 0.5);
-    REQUIRE(std::abs(jd1 - 2451545.0) < 1e-6);
+    auto jd1 = julian::julian_date_from_doy(2000, 1, 0.5);
+    REQUIRE(jd1);
+    REQUIRE(std::abs(*jd1 - 2451545.0) < 1e-6);
 
-    double jd2 = julian::julian_date_from_doy(2021, 275, 0.59097222);
-    REQUIRE(std::abs(jd2 - 2459490.09097222) < 1e-6);
-}
-
-TEST_CASE("doy_to_month_day returns false for invalid day of year") {
-    int month, day;
-    bool ok = julian::doy_to_month_day(2021, 366, month, day);
-    REQUIRE_FALSE(ok);
-
-TEST_CASE("julian_date_from_doy computes correct Julian date for known values") {
-    REQUIRE(std::abs(julian::julian_date_from_doy(2000, 1, 0.5) - 2451545.0) < 1e-6);
-    REQUIRE(std::abs(julian::julian_date_from_doy(2021, 275, 0.59097222) - 2459490.09097222) <
-            1e-6);
+    auto jd2 = julian::julian_date_from_doy(2021, 275, 0.59097222);
+    REQUIRE(jd2);
+    REQUIRE(std::abs(*jd2 - 2459490.09097222) < 1e-6);
 }
 
 TEST_CASE("doy_to_month_day handles valid and invalid day-of-year inputs") {


### PR DESCRIPTION
## Summary
- Remove duplicated include and redundant test cases in `julian_test.cpp`
- Update tests to handle optional return value and consolidate `doy_to_month_day` checks
- Use Catch2's main library for building the test

## Testing
- `g++ tests/julian_test.cpp -std=c++17 -I. -o julian_test -L/usr/lib -lCatch2Main -lCatch2`
- `./julian_test`


------
https://chatgpt.com/codex/tasks/task_e_68c1f840617483288713b387ad9e8dbb