### PR TITLE
Add stop command to openastrovizd

### DIFF
--- a/daemon/openastrovizd/src/main.rs
+++ b/daemon/openastrovizd/src/main.rs
@@ -17,6 +17,8 @@ struct Cli {
 enum Commands {
     /// Start the daemon
     Start,
+    /// Stop the daemon
+    Stop,
     /// Show daemon status
     Status,
     /// Run benchmarks for a backend
@@ -37,6 +39,13 @@ fn main() {
                 std::process::exit(1);
             }
         },
+        Some(Commands::Stop) => match daemon::stop_daemon() {
+            Ok(message) => println!("{message}"),
+            Err(e) => {
+                eprintln!("Failed to stop daemon: {e}");
+                std::process::exit(1);
+            }
+        },
         Some(Commands::Status) => match daemon::check_status() {
             Ok(status) => println!("{status}"),
             Err(e) => {
@@ -44,21 +53,19 @@ fn main() {
                 std::process::exit(1);
             }
         },
-        Some(Commands::Bench { backend }) => {
-            match bench_backend(backend) {
-                Ok(duration) => {
-                    println!("Benchmark for {backend:?} completed in {:?}", duration);
-                }
-                Err(BenchError::Unsupported) => {
-                    eprintln!("Backend {backend:?} is unsupported");
-                    std::process::exit(1);
-                }
-                Err(BenchError::Failed) => {
-                    eprintln!("Benchmark for {backend:?} failed");
-                    std::process::exit(1);
-                }
+        Some(Commands::Bench { backend }) => match bench_backend(backend) {
+            Ok(duration) => {
+                println!("Benchmark for {backend:?} completed in {:?}", duration);
             }
-        }
+            Err(BenchError::Unsupported) => {
+                eprintln!("Backend {backend:?} is unsupported");
+                std::process::exit(1);
+            }
+            Err(BenchError::Failed) => {
+                eprintln!("Benchmark for {backend:?} failed");
+                std::process::exit(1);
+            }
+        },
         None => {
             println!("openastrovizd {}", env!("CARGO_PKG_VERSION"));
         }

--- a/daemon/openastrovizd/tests/cli.rs
+++ b/daemon/openastrovizd/tests/cli.rs
@@ -88,3 +88,35 @@ fn start_subcommand_outputs_message() {
         .stdout(contains("Daemon started"));
     cleanup();
 }
+
+#[test]
+fn stop_subcommand_stops_daemon_and_removes_pid() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    cleanup();
+    // Start the daemon first
+    Command::cargo_bin("openastrovizd")
+        .unwrap()
+        .arg("start")
+        .assert()
+        .success();
+    let pid_path = std::env::temp_dir().join("openastrovizd.pid");
+    assert!(pid_path.exists());
+
+    // Stop the daemon
+    Command::cargo_bin("openastrovizd")
+        .unwrap()
+        .arg("stop")
+        .assert()
+        .success()
+        .stdout(contains("Daemon stopped"));
+
+    // Status should report not running and PID file should be removed
+    Command::cargo_bin("openastrovizd")
+        .unwrap()
+        .arg("status")
+        .assert()
+        .success()
+        .stdout(contains("Daemon is not running"));
+    assert!(!pid_path.exists());
+    cleanup();
+}


### PR DESCRIPTION
## Summary
- add `Stop` subcommand to openastrovizd CLI
- implement `stop_daemon` to terminate process and remove PID file
- test that `stop` command stops daemon and cleans up PID file

## Testing
- `cargo test -p openastrovizd`


------
https://chatgpt.com/codex/tasks/task_e_68c1f83f95c8832891e8f2d69537560a