### PR TITLE
Refine Windows PID check

### DIFF
--- a/daemon/openastrovizd/tests/cli.rs
+++ b/daemon/openastrovizd/tests/cli.rs
@@ -88,3 +88,21 @@ fn start_subcommand_outputs_message() {
         .stdout(contains("Daemon started"));
     cleanup();
 }
+
+#[test]
+fn start_then_status_subcommand_reports_running() {
+    let _lock = TEST_MUTEX.lock().unwrap();
+    cleanup();
+    Command::cargo_bin("openastrovizd")
+        .unwrap()
+        .arg("start")
+        .assert()
+        .success();
+    Command::cargo_bin("openastrovizd")
+        .unwrap()
+        .arg("status")
+        .assert()
+        .success()
+        .stdout(contains("Daemon is running"));
+    cleanup();
+}


### PR DESCRIPTION
## Summary
- Improve Windows process detection by filtering tasklist output and verifying a single line match.
- Add CLI integration test to confirm daemon status reporting after start.

## Testing
- `pre-commit run --files daemon/openastrovizd/src/daemon.rs daemon/openastrovizd/tests/cli.rs`
- `cargo test -p openastrovizd`


------
https://chatgpt.com/codex/tasks/task_e_68c1f83e2e10832891bfea0e8ad2919b