### PR TITLE
Use black_box in bench to avoid loop optimization

### DIFF
--- a/daemon/openastrovizd/src/bench.rs
+++ b/daemon/openastrovizd/src/bench.rs
@@ -1,3 +1,4 @@
+use std::hint::black_box;
 use std::time::{Duration, Instant};
 
 use crate::backend::Backend;
@@ -29,7 +30,7 @@ pub fn bench_backend(backend: Backend) -> Result<Duration, BenchError> {
             }
             let elapsed = start.elapsed();
             // use sum so optimizer doesn't remove loop
-            let _ = sum;
+            black_box(sum);
             Ok(elapsed)
         }
     }


### PR DESCRIPTION
## Summary
- prevent the bench loop from being optimized out by using `black_box`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68c1f83cd4e88328a1fe64d92c41c596