### PR TITLE
refactor: share daemon test cleanup util

### DIFF
--- a/daemon/openastrovizd/tests/cli.rs
+++ b/daemon/openastrovizd/tests/cli.rs
@@ -1,29 +1,11 @@
 use assert_cmd::Command;
 use predicates::prelude::*;
 use predicates::str::contains;
-use std::fs;
-#[cfg(not(unix))]
-use std::process::Command as StdCommand;
 use std::sync::Mutex;
 
 static TEST_MUTEX: Mutex<()> = Mutex::new(());
 
-fn cleanup() {
-    let pid_path = std::env::temp_dir().join("openastrovizd.pid");
-    if let Ok(pid_str) = fs::read_to_string(&pid_path) {
-        if let Ok(pid) = pid_str.trim().parse::<i32>() {
-            #[cfg(unix)]
-            unsafe {
-                libc::kill(pid, libc::SIGTERM);
-            }
-            #[cfg(not(unix))]
-            let _ = StdCommand::new("taskkill")
-                .args(["/PID", &pid.to_string(), "/F"])
-                .status();
-        }
-    }
-    let _ = fs::remove_file(pid_path);
-}
+mod util;
 
 #[test]
 fn runs_without_args_shows_version() {
@@ -36,7 +18,7 @@ fn runs_without_args_shows_version() {
 #[test]
 fn status_subcommand() {
     let _lock = TEST_MUTEX.lock().unwrap();
-    cleanup();
+    util::cleanup();
     let mut cmd = Command::cargo_bin("openastrovizd").unwrap();
     cmd.arg("status")
         .assert()
@@ -79,12 +61,12 @@ fn help_includes_description() {
 #[test]
 fn start_subcommand_outputs_message() {
     let _lock = TEST_MUTEX.lock().unwrap();
-    cleanup();
+    util::cleanup();
     Command::cargo_bin("openastrovizd")
         .unwrap()
         .arg("start")
         .assert()
         .success()
         .stdout(contains("Daemon started"));
-    cleanup();
+    util::cleanup();
 }

--- a/daemon/openastrovizd/tests/util/mod.rs
+++ b/daemon/openastrovizd/tests/util/mod.rs
@@ -1,0 +1,22 @@
+use std::fs;
+#[cfg(not(unix))]
+use std::process::Command;
+
+/// Removes the pid file and terminates the daemon process if it is running.
+pub fn cleanup() {
+    let pid_path = std::env::temp_dir().join("openastrovizd.pid");
+    if let Ok(pid_str) = fs::read_to_string(&pid_path) {
+        if let Ok(pid) = pid_str.trim().parse::<i32>() {
+            #[cfg(unix)]
+            unsafe {
+                libc::kill(pid, libc::SIGTERM);
+            }
+            #[cfg(not(unix))]
+            let _ = Command::new("taskkill")
+                .args(["/PID", &pid.to_string(), "/F"])
+                .status();
+        }
+    }
+    let _ = fs::remove_file(pid_path);
+}
+


### PR DESCRIPTION
## Summary
- extract daemon cleanup helper into dedicated test util
- reuse shared cleanup in CLI and daemon tests

## Testing
- `cargo test -p openastrovizd`


------
https://chatgpt.com/codex/tasks/task_e_68c1f83b8f94832892928aff6deded09