### PR TITLE
Clean up daemon test helpers

### DIFF
--- a/daemon/openastrovizd/src/daemon.rs
+++ b/daemon/openastrovizd/src/daemon.rs
@@ -122,37 +122,6 @@ pub fn stop_daemon() -> Result<String, io::Error> {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use std::sync::Mutex;
-
-    static TEST_MUTEX: Mutex<()> = Mutex::new(());
-
-    fn cleanup() {
-        let pid_path = pid_file();
-        if let Ok(pid_str) = fs::read_to_string(&pid_path) {
-            if let Ok(pid) = pid_str.trim().parse::<i32>() {
-
-                #[cfg(unix)]
-                unsafe {
-                    libc::kill(pid as i32, libc::SIGTERM);
-                }
-                #[cfg(not(unix))]
-                let _ = Command::new("taskkill")
-                    .args(["/PID", &pid.to_string(), "/F"])
-                    .status();
-                let _ = fs::remove_file(pid_file());
-                Ok(String::from("Daemon stopped"))
-            } else {
-                Ok(String::from("Daemon is not running"))
-            }
-        }
-        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(String::from("Daemon is not running")),
-        Err(e) => Err(e),
-    }
-}
-
-#[cfg(test)]
 #[path = "../tests/util/mod.rs"]
 mod util;
 

--- a/daemon/openastrovizd/tests/cli.rs
+++ b/daemon/openastrovizd/tests/cli.rs
@@ -6,6 +6,7 @@ use std::sync::Mutex;
 static TEST_MUTEX: Mutex<()> = Mutex::new(());
 
 mod util;
+use util::cleanup;
 
 #[test]
 fn runs_without_args_shows_version() {
@@ -18,7 +19,7 @@ fn runs_without_args_shows_version() {
 #[test]
 fn status_subcommand() {
     let _lock = TEST_MUTEX.lock().unwrap();
-    util::cleanup();
+    cleanup();
     let mut cmd = Command::cargo_bin("openastrovizd").unwrap();
     cmd.arg("status")
         .assert()
@@ -61,14 +62,14 @@ fn help_includes_description() {
 #[test]
 fn start_subcommand_outputs_message() {
     let _lock = TEST_MUTEX.lock().unwrap();
-    util::cleanup();
+    cleanup();
     Command::cargo_bin("openastrovizd")
         .unwrap()
         .arg("start")
         .assert()
         .success()
         .stdout(contains("Daemon started"));
-    util::cleanup();
+    cleanup();
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- remove the unused duplicate tests module from `daemon/openastrovizd/src/daemon.rs`
- consolidate cleanup helper usage so tests import it from `daemon/openastrovizd/tests/util`

## Testing
- cargo test -p openastrovizd

------
https://chatgpt.com/codex/tasks/task_e_68d82c4ff4bc83289941aba23d9233d8