### PR TITLE
Prevent starting duplicate daemon instances

### DIFF
--- a/daemon/openastrovizd/tests/cli.rs
+++ b/daemon/openastrovizd/tests/cli.rs
@@ -3,6 +3,8 @@ use predicates::prelude::*;
 use predicates::str::contains;
 use std::sync::Mutex;
 
+use util::cleanup;
+
 static TEST_MUTEX: Mutex<()> = Mutex::new(());
 
 mod util;


### PR DESCRIPTION
## Summary
- check the PID file before spawning openastrovizd and refuse to start when a live daemon already exists
- clean up stale PID files on startup and add a regression test covering duplicate launch and stale file scenarios
- expose the test cleanup helper in cli integration tests to restore compilation

## Testing
- cargo test -p openastrovizd

------
https://chatgpt.com/codex/tasks/task_e_68d82c4975688328aec99cfdd78adfb1