### PR TITLE
Fix C++ test suite compilation without Catch2

### DIFF
--- a/tests/julian_test.cpp
+++ b/tests/julian_test.cpp
@@ -1,44 +1,46 @@
 #include "julian.hpp"
-#define CATCH_CONFIG_MAIN
-#if __has_include(<catch2/catch_all.hpp>)
-#include <catch2/catch_all.hpp>
-#elif __has_include(<catch2/catch.hpp>)
-#include <catch2/catch.hpp>
-#else
-#error "Catch2 headers not found"
-#endif
-#include <cmath>
 
-TEST_CASE("julian_date_from_doy computes expected Julian dates") {
+#include <cassert>
+#include <cmath>
+#include <cstdlib>
+#include <iostream>
+
+namespace {
+
+void test_julian_date_from_doy() {
     auto jd1 = julian::julian_date_from_doy(2000, 1, 0.5);
-    REQUIRE(jd1);
-    REQUIRE(std::abs(*jd1 - 2451545.0) < 1e-6);
+    assert(jd1.has_value());
+    assert(std::abs(*jd1 - 2451545.0) < 1e-6);
 
     auto jd2 = julian::julian_date_from_doy(2021, 275, 0.59097222);
-    REQUIRE(jd2);
-    REQUIRE(std::abs(*jd2 - 2459490.09097222) < 1e-6);
+    assert(jd2.has_value());
+    assert(std::abs(*jd2 - 2459490.09097222) < 1e-6);
 }
 
-TEST_CASE("doy_to_month_day handles valid and invalid day-of-year inputs") {
+void test_doy_to_month_day_valid_and_invalid_inputs() {
     int month = 0;
     int day = 0;
 
-    SECTION("valid day-of-year returns correct month and day") {
-        bool ok = julian::doy_to_month_day(2021, 275, month, day);
-        REQUIRE(ok);
-        REQUIRE(month == 10);
-        REQUIRE(day == 2);
-    }
+    bool ok = julian::doy_to_month_day(2021, 275, month, day);
+    assert(ok);
+    assert(month == 10);
+    assert(day == 2);
 
-    SECTION("valid leap day-of-year returns December 31") {
-        bool ok = julian::doy_to_month_day(2020, 366, month, day);
-        REQUIRE(ok);
-        REQUIRE(month == 12);
-        REQUIRE(day == 31);
-    }
+    ok = julian::doy_to_month_day(2020, 366, month, day);
+    assert(ok);
+    assert(month == 12);
+    assert(day == 31);
 
-    SECTION("invalid day-of-year returns false") {
-        bool ok = julian::doy_to_month_day(2021, 366, month, day);
-        REQUIRE_FALSE(ok);
-    }
+    ok = julian::doy_to_month_day(2021, 366, month, day);
+    assert(!ok);
+}
+
+} // namespace
+
+int main() {
+    test_julian_date_from_doy();
+    test_doy_to_month_day_valid_and_invalid_inputs();
+
+    std::cout << "All C++ tests passed.\n";
+    return EXIT_SUCCESS;
 }


### PR DESCRIPTION
### Motivation
- The C++ test binary failed to compile in environments without Catch2, causing CI and local test runs to break.
- The intent is to make the test suite self-contained so it can run without external test framework headers.

### Description
- Replaced the Catch2-based test harness in `tests/julian_test.cpp` with a small, self-contained `assert`-based test driver. 
- Removed the `#define CATCH_CONFIG_MAIN` and `#include <catch2/...>` checks and added `#include <cassert>`, `#include <cstdlib>`, and `#include <iostream>` instead. 
- Converted the `TEST_CASE`/`SECTION` style tests into two plain test functions and added a `main()` that runs them and prints a success message. 
- Preserved all existing assertions validating `julian_date_from_doy` and `doy_to_month_day` behavior, including leap-year handling.

### Testing
- Ran `./scripts/run_tests.sh`, which compiles the test binary and executes it, and the script completed successfully. 
- The C++ tests printed `All C++ tests passed.` and returned a successful exit code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd69a3e9ec8328a48f6636cc7f0bc7)